### PR TITLE
fix: Decrease Client Registration Authorisation validity period to 5 sec

### DIFF
--- a/app/src/main/java/tech/relaycorp/gateway/domain/endpoint/EndpointRegistration.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/domain/endpoint/EndpointRegistration.kt
@@ -58,7 +58,7 @@ class EndpointRegistration
     }
 
     companion object {
-        private const val CRA_VALIDITY_SECONDS: Long = 15
+        private const val CRA_VALIDITY_SECONDS: Long = 5
         private const val ENDPOINT_CERTIFICATE_VALIDITY_YEARS = 3L
     }
 }

--- a/app/src/test/java/tech/relaycorp/gateway/domain/endpoint/EndpointRegistrationTest.kt
+++ b/app/src/test/java/tech/relaycorp/gateway/domain/endpoint/EndpointRegistrationTest.kt
@@ -53,7 +53,7 @@ class EndpointRegistrationTest {
         }
 
         @Test
-        fun `Authorization should be valid for 15 seconds`() = runBlockingTest {
+        fun `Authorization should be valid for 5 seconds`() = runBlockingTest {
             val craSerialized = endpointRegistration.authorize(dummyApplicationId)
 
             val cra = ClientRegistrationAuthorization.deserialize(
@@ -62,7 +62,7 @@ class EndpointRegistrationTest {
             )
 
             val craTTL = ChronoUnit.SECONDS.between(ZonedDateTime.now(), cra.expiryDate)
-            assertTrue(craTTL in 13..15) // Give some wiggle room
+            assertTrue(craTTL in 3..5) // Give some wiggle room
         }
     }
 


### PR DESCRIPTION
I had to increase it to 15 seconds just because it was breaking an instrumentation test but #88 should make it possible to go back to the original 5 seconds.