### PR TITLE
fix(CogRPC): Use OkHTTP instead of Netty

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,8 +113,8 @@ dependencies {
 
     // Relaynet
     implementation 'tech.relaycorp:relaynet:1.36.3'
-    implementation 'com.github.relaycorp:relaynet-cogrpc-jvm:PR43-SNAPSHOT'
-    implementation 'com.github.relaycorp:relaynet-cogrpc-jvm-okhttp:PR1-SNAPSHOT'
+    implementation 'com.github.relaycorp:relaynet-cogrpc-jvm:1.1.2'
+    implementation 'com.github.relaycorp:relaynet-cogrpc-jvm-okhttp:1.1.0'
 
     // Android TLS support for Netty
     implementation "io.netty:netty-handler:4.1.51.Final"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -114,6 +114,7 @@ dependencies {
     // Relaynet
     implementation 'tech.relaycorp:relaynet:1.36.3'
     implementation 'com.github.relaycorp:relaynet-cogrpc-jvm:PR43-SNAPSHOT'
+    implementation "io.grpc:grpc-okhttp:1.31.1"
 
     // Android TLS support for Netty
     implementation "io.netty:netty-handler:4.1.51.Final"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,7 +113,7 @@ dependencies {
 
     // Relaynet
     implementation 'tech.relaycorp:relaynet:1.36.3'
-    implementation 'tech.relaycorp:relaynet-cogrpc:1.1.1'
+    implementation 'com.github.relaycorp:relaynet-cogrpc-jvm:PR43-SNAPSHOT'
 
     // Android TLS support for Netty
     implementation "io.netty:netty-handler:4.1.51.Final"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,8 +113,8 @@ dependencies {
 
     // Relaynet
     implementation 'tech.relaycorp:relaynet:1.36.3'
-    implementation 'com.github.relaycorp:relaynet-cogrpc-jvm:1.1.2'
-    implementation 'com.github.relaycorp:relaynet-cogrpc-jvm-okhttp:1.1.0'
+    implementation 'tech.relaycorp:relaynet-cogrpc:1.1.2'
+    implementation 'tech.relaycorp:relaynet-cogrpc-okhttp:1.1.0'
 
     // Android TLS support for Netty
     implementation "io.netty:netty-handler:4.1.51.Final"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -114,7 +114,7 @@ dependencies {
     // Relaynet
     implementation 'tech.relaycorp:relaynet:1.36.3'
     implementation 'com.github.relaycorp:relaynet-cogrpc-jvm:PR43-SNAPSHOT'
-    implementation "io.grpc:grpc-okhttp:1.31.1"
+    implementation 'com.github.relaycorp:relaynet-cogrpc-jvm-okhttp:PR1-SNAPSHOT'
 
     // Android TLS support for Netty
     implementation "io.netty:netty-handler:4.1.51.Final"

--- a/app/src/main/java/tech/relaycorp/gateway/domain/courier/CargoCollection.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/domain/courier/CargoCollection.kt
@@ -1,20 +1,17 @@
 package tech.relaycorp.gateway.domain.courier
 
-import io.grpc.okhttp.OkHttpChannelBuilder
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
+import tech.relaycorp.cogrpc.okhttp.OkHTTPChannelBuilderProvider
 import tech.relaycorp.gateway.background.ConnectionState
 import tech.relaycorp.gateway.background.ConnectionStateObserver
 import tech.relaycorp.gateway.common.Logging.logger
 import tech.relaycorp.gateway.data.disk.CargoStorage
-import tech.relaycorp.relaynet.cogrpc.client.ChannelBuilderProvider
 import tech.relaycorp.relaynet.cogrpc.client.CogRPCClient
-import java.security.SecureRandom
 import java.util.logging.Level
 import javax.inject.Inject
-import javax.net.ssl.SSLContext
 
 class CargoCollection
 @Inject constructor(
@@ -25,23 +22,12 @@ class CargoCollection
     private val processCargo: ProcessCargo,
     private val processParcels: ProcessParcels
 ) {
-    private val grpcProvider : ChannelBuilderProvider<OkHttpChannelBuilder> = { address, trustManager ->
-        OkHttpChannelBuilder.forAddress(address.hostName, address.port)
-            .let {
-                if (trustManager != null) {
-                    val sslContext = SSLContext.getInstance("TLS")
-                    sslContext.init(null, arrayOf(trustManager), SecureRandom())
-                    it.sslSocketFactory(sslContext.socketFactory)
-                } else {
-                    it
-                }
-            }
-    }
 
     @Throws(Disconnected::class)
     suspend fun collect() {
-        val client =
-            getCourierAddress()?.let { clientBuilder.build(it, grpcProvider) } ?: throw Disconnected()
+        val client = getCourierAddress()?.let {
+            clientBuilder.build(it, OkHTTPChannelBuilderProvider.Companion::makeBuilder)
+        } ?: throw Disconnected()
 
         try {
             client

--- a/app/src/main/java/tech/relaycorp/gateway/domain/courier/CargoDelivery.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/domain/courier/CargoDelivery.kt
@@ -1,15 +1,19 @@
 package tech.relaycorp.gateway.domain.courier
 
+import io.grpc.okhttp.OkHttpChannelBuilder
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
-import tech.relaycorp.gateway.background.ConnectionStateObserver
 import tech.relaycorp.gateway.background.ConnectionState
+import tech.relaycorp.gateway.background.ConnectionStateObserver
 import tech.relaycorp.relaynet.CargoDeliveryRequest
+import tech.relaycorp.relaynet.cogrpc.client.ChannelBuilderProvider
 import tech.relaycorp.relaynet.cogrpc.client.CogRPCClient
+import java.security.SecureRandom
 import java.util.UUID
 import javax.inject.Inject
+import javax.net.ssl.SSLContext
 
 class CargoDelivery
 @Inject constructor(
@@ -17,10 +21,22 @@ class CargoDelivery
     private val connectionStateObserver: ConnectionStateObserver,
     private val generateCargo: GenerateCargo
 ) {
+    private val grpcProvider : ChannelBuilderProvider<OkHttpChannelBuilder> = { address, trustManager ->
+        OkHttpChannelBuilder.forAddress(address.hostName, address.port)
+            .let {
+                if (trustManager != null) {
+                    val sslContext = SSLContext.getInstance("TLS")
+                    sslContext.init(null, arrayOf(trustManager), SecureRandom())
+                    it.sslSocketFactory(sslContext.socketFactory)
+                } else {
+                    it
+                }
+            }
+    }
 
     suspend fun deliver() {
         val client =
-            getCourierAddress()?.let { clientBuilder.build(it) } ?: throw Disconnected()
+            getCourierAddress()?.let { clientBuilder.build(it, grpcProvider) } ?: throw Disconnected()
 
         try {
             client

--- a/app/src/main/java/tech/relaycorp/gateway/domain/courier/CargoDelivery.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/domain/courier/CargoDelivery.kt
@@ -1,19 +1,16 @@
 package tech.relaycorp.gateway.domain.courier
 
-import io.grpc.okhttp.OkHttpChannelBuilder
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
+import tech.relaycorp.cogrpc.okhttp.OkHTTPChannelBuilderProvider
 import tech.relaycorp.gateway.background.ConnectionState
 import tech.relaycorp.gateway.background.ConnectionStateObserver
 import tech.relaycorp.relaynet.CargoDeliveryRequest
-import tech.relaycorp.relaynet.cogrpc.client.ChannelBuilderProvider
 import tech.relaycorp.relaynet.cogrpc.client.CogRPCClient
-import java.security.SecureRandom
 import java.util.UUID
 import javax.inject.Inject
-import javax.net.ssl.SSLContext
 
 class CargoDelivery
 @Inject constructor(
@@ -21,22 +18,12 @@ class CargoDelivery
     private val connectionStateObserver: ConnectionStateObserver,
     private val generateCargo: GenerateCargo
 ) {
-    private val grpcProvider : ChannelBuilderProvider<OkHttpChannelBuilder> = { address, trustManager ->
-        OkHttpChannelBuilder.forAddress(address.hostName, address.port)
-            .let {
-                if (trustManager != null) {
-                    val sslContext = SSLContext.getInstance("TLS")
-                    sslContext.init(null, arrayOf(trustManager), SecureRandom())
-                    it.sslSocketFactory(sslContext.socketFactory)
-                } else {
-                    it
-                }
-            }
-    }
 
     suspend fun deliver() {
         val client =
-            getCourierAddress()?.let { clientBuilder.build(it, grpcProvider) } ?: throw Disconnected()
+            getCourierAddress()?.let {
+                clientBuilder.build(it, OkHTTPChannelBuilderProvider.Companion::makeBuilder)
+            } ?: throw Disconnected()
 
         try {
             client


### PR DESCRIPTION
Because of https://github.com/grpc/grpc-java/issues/7385

TODO:

- [x] Test this throughly.
- [x] Release https://github.com/relaycorp/relaynet-cogrpc-jvm/pull/43 and use it here.