### PR TITLE
fix: Upgrade Relaynet library to use AES-CBC

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,7 +115,7 @@ dependencies {
     kapt 'com.google.dagger:dagger-compiler:2.28.1'
 
     // Relaynet
-    implementation 'tech.relaycorp:relaynet:1.39.0'
+    implementation 'tech.relaycorp:relaynet:1.39.1'
     implementation 'tech.relaycorp:cogrpc:1.1.6'
     implementation 'tech.relaycorp:cogrpc-okhttp:1.1.5'
     testImplementation "tech.relaycorp:relaynet-testing:$relaynetTestingVersion"


### PR DESCRIPTION
This change will allow the Android GW to (de)encrypt cargo exchanged with the public gateway. See: https://github.com/relaycorp/relayverse/issues/16

The counterpart to this change will land on the server in a few minutes: https://github.com/relaycorp/relaynet-internet-gateway/pull/299
