### PR TITLE
fix: Only ping Google if we can't reach the public gateway

### DIFF
--- a/app/src/main/java/tech/relaycorp/gateway/background/ConnectionStateObserver.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/background/ConnectionStateObserver.kt
@@ -57,12 +57,10 @@ class ConnectionStateObserver
     fun observe(): Flow<ConnectionState> = state
 
     private suspend fun checkNetworkState(network: Network): ConnectionState {
-        return if (checkInternetAccess.check()) {
-            if (checkPublicGatewayAccess.check()) {
-                ConnectionState.InternetAndPublicGateway
-            } else {
-                ConnectionState.InternetWithoutPublicGateway
-            }
+        return if (checkPublicGatewayAccess.check()) {
+            ConnectionState.InternetAndPublicGateway
+        } else if (checkInternetAccess.check()) {
+            ConnectionState.InternetWithoutPublicGateway
         } else if (network.isWifi) {
             val serverAddress = hotspotSourceIpAddress
                 ?: return ConnectionState.WiFiWithUnknown


### PR DESCRIPTION
In order to minimise the risk of Google marking these requests as malicious, minimise reliance on Google and minimise the data Google gets about our users.
