### PR TITLE
fix: Align text when syncing with courier

### DIFF
--- a/app/src/main/res/layout/activity_courier_connection.xml
+++ b/app/src/main/res/layout/activity_courier_connection.xml
@@ -94,9 +94,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="16dp"
                     android:text="@string/courier_instructions_2"
-                    app:layout_constrainedWidth="true"
                     app:layout_constraintBottom_toBottomOf="@id/instruction2Bullet"
-                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@id/instruction2Bullet"
                     app:layout_constraintTop_toTopOf="@id/instruction2Bullet" />
 


### PR DESCRIPTION
Fixes #243.

I don't fully understand what I'm doing, but I noticed these two lines I'm removing aren't used by the other two items on the list. And the alignment issue seems fixed.

![Screenshot_20210113-150411](https://user-images.githubusercontent.com/369863/104469703-b1c4c580-55b0-11eb-9135-2399fb976de1.png)
