### PR TITLE
chore: Remove traceback from ping failure logs

### DIFF
--- a/app/src/main/java/tech/relaycorp/gateway/background/CheckPublicGatewayAccess.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/background/CheckPublicGatewayAccess.kt
@@ -15,7 +15,7 @@ class CheckPublicGatewayAccess
         val address = try {
             publicGatewayPreferences.getPoWebAddress()
         } catch (exc: PublicAddressResolutionException) {
-            logger.log(Level.WARNING, "Failed to resolve PoWeb address", exc)
+            logger.log(Level.WARNING, "Failed to resolve PoWeb address (${exc.message})")
             return false
         }
         return pingRemoteServer.pingURL("https://${address.host}:${address.port}")

--- a/app/src/main/java/tech/relaycorp/gateway/background/PingRemoteServer.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/background/PingRemoteServer.kt
@@ -41,10 +41,13 @@ class PingRemoteServer
             ktorClient.head<Unit>(url)
             true
         } catch (e: IOException) {
-            logger.log(Level.INFO, "Could not ping $url", e)
+            logger.log(Level.INFO, "Could not ping $url (${e.message})")
             false
         } catch (e: ResponseException) {
-            logger.log(Level.INFO, "Successfully pinged $url but got a response exception", e)
+            logger.log(
+                Level.INFO,
+                "Successfully pinged $url but got a response exception (${e.message})"
+            )
             true
         }
 }


### PR DESCRIPTION
Because we get a ton of those when the device is disconnected from the Internet, and it makes it hard to keep up with the logs when troubleshooting.
