### PR TITLE
fix: Self-issue certificate when app is used for the first time

### DIFF
--- a/app/src/androidTest/java/tech/relaycorp/gateway/background/endpoint/EndpointPreRegistrationServiceTest.kt
+++ b/app/src/androidTest/java/tech/relaycorp/gateway/background/endpoint/EndpointPreRegistrationServiceTest.kt
@@ -43,7 +43,7 @@ class EndpointPreRegistrationServiceTest {
     fun setUp() {
         AppTestProvider.component.inject(this)
         runBlocking {
-            localConfig.generateKeyPair()
+            localConfig.bootstrap()
             publicGatewayPreferences.setRegistrationState(RegistrationState.Done)
         }
     }

--- a/app/src/androidTest/java/tech/relaycorp/gateway/background/endpoint/EndpointPreRegistrationServiceTest.kt
+++ b/app/src/androidTest/java/tech/relaycorp/gateway/background/endpoint/EndpointPreRegistrationServiceTest.kt
@@ -45,6 +45,7 @@ class EndpointPreRegistrationServiceTest {
     fun setUp() {
         AppTestProvider.component.inject(this)
         runBlocking(coroutineContext) {
+            localConfig.bootstrap()
             publicGatewayPreferences.setRegistrationState(RegistrationState.Done)
         }
     }

--- a/app/src/androidTest/java/tech/relaycorp/gateway/background/endpoint/EndpointPreRegistrationServiceTest.kt
+++ b/app/src/androidTest/java/tech/relaycorp/gateway/background/endpoint/EndpointPreRegistrationServiceTest.kt
@@ -21,6 +21,7 @@ import tech.relaycorp.gateway.data.model.RegistrationState
 import tech.relaycorp.gateway.data.preference.PublicGatewayPreferences
 import tech.relaycorp.gateway.domain.LocalConfig
 import tech.relaycorp.gateway.test.AppTestProvider
+import tech.relaycorp.gateway.test.WaitAssertions.suspendWaitFor
 import tech.relaycorp.gateway.test.WaitAssertions.waitFor
 import tech.relaycorp.relaynet.messages.control.PrivateNodeRegistrationAuthorization
 import java.nio.charset.Charset
@@ -43,7 +44,7 @@ class EndpointPreRegistrationServiceTest {
     fun setUp() {
         AppTestProvider.component.inject(this)
         runBlocking {
-            localConfig.bootstrap()
+            suspendWaitFor { localConfig.getKeyPair() }
             publicGatewayPreferences.setRegistrationState(RegistrationState.Done)
         }
     }

--- a/app/src/androidTest/java/tech/relaycorp/gateway/background/endpoint/EndpointPreRegistrationServiceTest.kt
+++ b/app/src/androidTest/java/tech/relaycorp/gateway/background/endpoint/EndpointPreRegistrationServiceTest.kt
@@ -20,6 +20,7 @@ import tech.relaycorp.gateway.data.model.RegistrationState
 import tech.relaycorp.gateway.data.preference.PublicGatewayPreferences
 import tech.relaycorp.gateway.domain.LocalConfig
 import tech.relaycorp.gateway.test.AppTestProvider
+import tech.relaycorp.gateway.test.WaitAssertions.suspendWaitFor
 import tech.relaycorp.gateway.test.WaitAssertions.waitFor
 import tech.relaycorp.relaynet.messages.control.PrivateNodeRegistrationAuthorization
 import java.nio.charset.Charset
@@ -45,7 +46,7 @@ class EndpointPreRegistrationServiceTest {
     fun setUp() {
         AppTestProvider.component.inject(this)
         runBlocking(coroutineContext) {
-            localConfig.bootstrap()
+            suspendWaitFor { localConfig.getKeyPair() }
             publicGatewayPreferences.setRegistrationState(RegistrationState.Done)
         }
     }

--- a/app/src/androidTest/java/tech/relaycorp/gateway/background/endpoint/EndpointPreRegistrationServiceTest.kt
+++ b/app/src/androidTest/java/tech/relaycorp/gateway/background/endpoint/EndpointPreRegistrationServiceTest.kt
@@ -43,6 +43,7 @@ class EndpointPreRegistrationServiceTest {
     fun setUp() {
         AppTestProvider.component.inject(this)
         runBlocking {
+            localConfig.generateKeyPair()
             publicGatewayPreferences.setRegistrationState(RegistrationState.Done)
         }
     }

--- a/app/src/main/java/tech/relaycorp/gateway/App.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/App.kt
@@ -3,6 +3,7 @@ package tech.relaycorp.gateway
 import android.app.Application
 import android.os.Build
 import android.os.StrictMode
+import androidx.annotation.VisibleForTesting
 import androidx.work.Configuration
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -45,7 +46,8 @@ open class App : Application() {
         }
     }
 
-    private val ioScope = CoroutineScope(Dispatchers.IO)
+    @VisibleForTesting
+    val backgroundScope = CoroutineScope(Dispatchers.IO)
 
     @Inject
     lateinit var foregroundAppMonitor: ForegroundAppMonitor
@@ -122,7 +124,7 @@ open class App : Application() {
     }
 
     private fun bootstrapGateway() {
-        ioScope.launch {
+        backgroundScope.launch {
             localConfig.bootstrap()
             if (mode != Mode.Test) {
                 registerGateway.registerIfNeeded()
@@ -131,7 +133,7 @@ open class App : Application() {
     }
 
     protected open fun startPublicSyncWhenPossible() {
-        ioScope.launch {
+        backgroundScope.launch {
             publicSync.sync()
         }
     }

--- a/app/src/main/java/tech/relaycorp/gateway/App.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/App.kt
@@ -122,11 +122,11 @@ open class App : Application() {
     }
 
     private fun bootstrapGateway() {
-        if (mode == Mode.Test) return
         ioScope.launch {
-            localConfig.generateKeyPair()
-            localConfig.generateCargoDeliveryAuth()
-            registerGateway.registerIfNeeded()
+            localConfig.bootstrap()
+            if (mode != Mode.Test) {
+                registerGateway.registerIfNeeded()
+            }
         }
     }
 

--- a/app/src/main/java/tech/relaycorp/gateway/App.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/App.kt
@@ -122,10 +122,10 @@ open class App : Application() {
     }
 
     private fun bootstrapGateway() {
+        if (mode == Mode.Test) return
         ioScope.launch {
             localConfig.generateKeyPair()
             localConfig.generateCargoDeliveryAuth()
-            if (mode == Mode.Test) return@launch
             registerGateway.registerIfNeeded()
         }
     }

--- a/app/src/main/java/tech/relaycorp/gateway/data/disk/SensitiveStore.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/data/disk/SensitiveStore.kt
@@ -22,6 +22,7 @@ class SensitiveStore
             .build()
     }
 
+    @Synchronized
     suspend fun store(location: String, data: ByteArray) {
         withContext(Dispatchers.IO) {
             delete(location)

--- a/app/src/main/java/tech/relaycorp/gateway/domain/LocalConfig.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/domain/LocalConfig.kt
@@ -62,6 +62,7 @@ class LocalConfig
         sensitiveStore.store(CDA_CERTIFICATE_FILE_NAME, it.serialize())
     }
 
+    @Synchronized
     suspend fun bootstrap() {
         try {
             getKeyPair()

--- a/app/src/main/java/tech/relaycorp/gateway/domain/LocalConfig.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/domain/LocalConfig.kt
@@ -54,7 +54,7 @@ class LocalConfig
     suspend fun getCargoDeliveryAuth() =
         sensitiveStore.read(CDA_CERTIFICATE_FILE_NAME)
             ?.let { Certificate.deserialize(it) }
-            ?: throw RuntimeException("No CDA was found")
+            ?: throw RuntimeException("No CDA issuer was found")
 
     suspend fun generateCargoDeliveryAuth() =
         generateCertificate().also { setCargoDeliveryAuth(it) }

--- a/app/src/main/java/tech/relaycorp/gateway/domain/courier/CalculateCRCMessageCreationDate.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/domain/courier/CalculateCRCMessageCreationDate.kt
@@ -21,6 +21,6 @@ class CalculateCRCMessageCreationDate
         )
 
     companion object {
-        private val CLOCK_DRIFT_TOLERANCE = 90.minutes
+        val CLOCK_DRIFT_TOLERANCE = 90.minutes
     }
 }


### PR DESCRIPTION
The problem here is that the certificate's start date was always later than the CCA's or the cargo's (whose creation time is 90 mins in the past).

I'm proposing to fix this by creating this certificate upfront, along with its key pair.

Fixes https://github.com/relaycorp/relaynet-courier-android/issues/277