### PR TITLE
chore(CI): Replace Huawei P8 lite with Asus Nexus 7

### DIFF
--- a/.github/data/firebase-test-lab.yml
+++ b/.github/data/firebase-test-lab.yml
@@ -4,9 +4,8 @@ spec:
   test: app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
   timeout: 30m
   device:
-    # Huawei P8 lite (physical). The oldest device we're testing and it's important not to use
-    # a Google phone just so we also make sure the manufacturer's ROM doesn't break the app.
-    - model: hwALE-H
+    # Asus Nexus 7 (physical). The oldest device we're testing.
+    - model: flo
       version: 21   # Android 5.0
       locale: en
       orientation: portrait


### PR DESCRIPTION
Firebase Test Lab doesn't seem to support Huawei P8 lite any more.
