### PR TITLE
fix: Use "422 Unprocessable Entity" when server refuses parcel

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -148,7 +148,7 @@ dependencies {
     implementation 'org.conscrypt:conscrypt-android:2.5.2'
 
     // Local and Internet-based Parcel Delivery Connections (PDCs)
-    implementation 'tech.relaycorp:poweb:1.5.18'
+    implementation 'tech.relaycorp:poweb:1.5.19'
     implementation "io.ktor:ktor-server-core:$ktorVersion"
     implementation "io.ktor:ktor-server-netty:$ktorVersion"
     implementation "io.ktor:ktor-websockets:$ktorVersion"

--- a/app/src/main/java/tech/relaycorp/gateway/pdc/local/routes/ParcelDeliveryRoute.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/pdc/local/routes/ParcelDeliveryRoute.kt
@@ -34,7 +34,7 @@ class ParcelDeliveryRoute
                 )
                 is StoreParcel.Result.InvalidParcel -> call.respondText(
                     "Parcel is invalid",
-                    status = HttpStatusCode.Forbidden
+                    status = HttpStatusCode.UnprocessableEntity
                 )
                 else -> call.respond(HttpStatusCode.Accepted)
             }

--- a/app/src/test/java/tech/relaycorp/gateway/pdc/local/routes/ParcelDeliveryRouteTest.kt
+++ b/app/src/test/java/tech/relaycorp/gateway/pdc/local/routes/ParcelDeliveryRouteTest.kt
@@ -66,7 +66,7 @@ class ParcelDeliveryRouteTest {
     }
 
     @Test
-    fun `Unauthorized parcels should be refused with an HTTP 403 response`() = runBlockingTest {
+    fun `Invalid parcels should be refused with an HTTP 422 response`() = runBlockingTest {
         whenever(storeParcel.store(any<ByteArray>(), eq(RecipientLocation.ExternalGateway)))
             .thenReturn(StoreParcel.Result.InvalidParcel(parcel, Exception()))
 
@@ -75,7 +75,7 @@ class ParcelDeliveryRouteTest {
                 addHeader("Content-Type", ContentType.PARCEL.toString())
             }
             with(call) {
-                assertEquals(HttpStatusCode.Forbidden, response.status())
+                assertEquals(HttpStatusCode.UnprocessableEntity, response.status())
                 assertEquals(KtorContentType.Text.Plain, response.contentType().withoutParameters())
                 assertEquals("Parcel is invalid", response.content)
             }


### PR DESCRIPTION
See:

- https://github.com/relaycorp/awala-poweb-jvm/pull/130
- https://github.com/AwalaNetwork/specs/commit/f4ef055baa67e1808efdb63be644592e5c052646
