### PR TITLE
fix: Restrict PDC server to clients on the same device

### DIFF
--- a/app/src/main/java/tech/relaycorp/gateway/pdc/local/PDCServer.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/pdc/local/PDCServer.kt
@@ -24,7 +24,7 @@ class PDCServer
 ) {
 
     private val server by lazy {
-        embeddedServer(Netty, PORT, watchPaths = emptyList()) {
+        embeddedServer(Netty, PORT, "127.0.0.1", watchPaths = emptyList()) {
             PDCServerConfiguration.configure(
                 this,
                 listOf(


### PR DESCRIPTION
I'm currently abusing this to debug #411, so this PR should be merged afterwards.