### PR TITLE
fix: Android 11 binding issue

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-gradle-
       - uses: eskatos/gradle-command-action@v1
         with:
-          arguments: build --scan
+          arguments: build --stacktrace --info --scan
       - name: Assemble instrumentation tests APK
         uses: eskatos/gradle-command-action@v1
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-gradle-
       - uses: eskatos/gradle-command-action@v1
         with:
-          arguments: build
+          arguments: build --scan
       - name: Assemble instrumentation tests APK
         uses: eskatos/gradle-command-action@v1
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - name: Cache Grade dependencies
         uses: actions/cache@v1
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - name: Cache Grade dependencies
         uses: actions/cache@v1
         with:
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-gradle-
       - uses: eskatos/gradle-command-action@v1
         with:
-          arguments: build --stacktrace --info --scan
+          arguments: build
       - name: Assemble instrumentation tests APK
         uses: eskatos/gradle-command-action@v1
         with:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ repositories {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion '30.0.2'
     ndkVersion '21.3.6528147'
 
@@ -42,7 +42,7 @@ android {
 
         minSdkVersion 21
 
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName project.findProperty("versionName") ?: "0.1"
 
@@ -162,10 +162,13 @@ dependencies {
     testImplementation "io.ktor:ktor-test-dispatcher:$ktorVersion"
 
     // ORM
-    def room_version = "2.3.0"
+    def room_version = '2.4.0-alpha04' // Mac M1 issue
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
+
+    // required to avoid crash on Android 12 API 31
+    implementation 'androidx.work:work-runtime-ktx:2.7.0-beta01'
 
     // Preferences
     implementation 'androidx.preference:preference-ktx:1.1.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
         <activity
             android:name=".ui.main.MainActivity"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.Gateway.Splash">
+            android:theme="@style/Theme.Gateway.Splash"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -70,20 +71,33 @@
             android:name=".background.endpoint.GatewaySyncService"
             android:exported="true"
             tools:ignore="ExportedService"
-            />
+            >
+            <intent-filter>
+                <action android:name="tech.relaycorp.gateway.SYNC"/>
+            </intent-filter>
+        </service>
 
         <service
             android:name=".background.endpoint.EndpointPreRegistrationService"
             android:exported="true"
             tools:ignore="ExportedService"
-            />
+            >
+            <intent-filter>
+                <action android:name="tech.relaycorp.gateway.ENDPOINT_PRE_REGISTRATION"/>
+            </intent-filter>
+        </service>
 
         <!-- Disable WorkManager auto-initialization -->
         <provider
-            android:name="androidx.work.impl.WorkManagerInitializer"
-            android:authorities="${applicationId}.workmanager-init"
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
             android:exported="false"
-            tools:node="remove" />
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
     </application>
 
     <queries>

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,7 @@ android.enableJetifier=true
 android.jetifier.blacklist=bouncycastle
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+# Issue with KaptWithoutKotlincTask, InvocationTargetException
+# Work arround https://youtrack.jetbrains.com/issue/KT-40750
+kapt.use.worker.api=false
+kapt.incremental.apt=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,3 @@ android.jetifier.blacklist=bouncycastle
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 # Issue with KaptWithoutKotlincTask, InvocationTargetException
-# Work arround https://youtrack.jetbrains.com/issue/KT-40750
-kapt.use.worker.api=false
-kapt.incremental.apt=false


### PR DESCRIPTION
Related with: relaycorp/awala-ping-android#158

Changes made to Package Visibility and security with Android 11.
https://developer.android.com/training/package-visibility/declaring#package-name

In this PR you can also see some changes to compile to Android 12, and Mac M1