### PR TITLE
fix: Generate CCA with correct sender's certificate

### DIFF
--- a/app/src/main/java/tech/relaycorp/gateway/domain/courier/GenerateCCA.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/domain/courier/GenerateCCA.kt
@@ -22,24 +22,24 @@ class GenerateCCA
 
     suspend fun generateSerialized(): ByteArray {
         val identityPrivateKey = localConfig.getIdentityKey()
-        val senderCertificate = localConfig.getCargoDeliveryAuth()
+        val cdaIssuer = localConfig.getCargoDeliveryAuth()
         val publicGatewayPublicKey = publicGatewayPreferences.getCertificate().subjectPublicKey
         val cda = issueDeliveryAuthorization(
             publicGatewayPublicKey,
             identityPrivateKey,
             ZonedDateTime.now().plusSeconds(TTL.inSeconds.toLong()),
-            senderCertificate
+            cdaIssuer
         )
         val ccr = CargoCollectionRequest(cda)
         val ccrCiphertext = gatewayManager.get().wrapMessagePayload(
             ccr,
             publicGatewayPublicKey.privateAddress,
-            senderCertificate.subjectPrivateAddress
+            cdaIssuer.subjectPrivateAddress
         )
         val cca = CargoCollectionAuthorization(
             recipientAddress = publicGatewayPreferences.getCogRPCAddress(),
             payload = ccrCiphertext,
-            senderCertificate = senderCertificate,
+            senderCertificate = localConfig.getIdentityCertificate(),
             creationDate = calculateCreationDate.calculate(),
             ttl = TTL.inSeconds.toInt()
         )

--- a/app/src/test/java/tech/relaycorp/gateway/domain/courier/GenerateCCATest.kt
+++ b/app/src/test/java/tech/relaycorp/gateway/domain/courier/GenerateCCATest.kt
@@ -18,6 +18,7 @@ import tech.relaycorp.relaynet.issueGatewayCertificate
 import tech.relaycorp.relaynet.messages.CargoCollectionAuthorization
 import tech.relaycorp.relaynet.testing.pki.CDACertPath
 import tech.relaycorp.relaynet.testing.pki.KeyPairSet
+import tech.relaycorp.relaynet.testing.pki.PDACertPath
 import java.time.Duration
 
 class GenerateCCATest : BaseDataTestCase() {
@@ -63,7 +64,7 @@ class GenerateCCATest : BaseDataTestCase() {
     }
 
     @Test
-    internal fun `generate in ByteArray`() = runBlockingTest {
+    fun `generate in ByteArray`() = runBlockingTest {
         val creationDate = nowInUtc()
         whenever(calculateCreationDate.calculate()).thenReturn(creationDate)
 
@@ -72,7 +73,7 @@ class GenerateCCATest : BaseDataTestCase() {
 
         cca.validate(null)
         assertEquals(ADDRESS, cca.recipientAddress)
-        assertEquals(localConfig.getCargoDeliveryAuth(), cca.senderCertificate)
+        assertEquals(PDACertPath.PRIVATE_GW, cca.senderCertificate)
         assertTrue(Duration.between(creationDate, cca.creationDate).abs().seconds <= 1)
 
         // Check it was encrypted with the public gateway's session key


### PR DESCRIPTION
The one issued by the public gateway.

This is needed so that we can fix https://github.com/relaycorp/relaynet-internet-gateway/issues/53