### PR TITLE
fix(CogRPC): Use Internet address as recipient when producing parcels

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -140,8 +140,8 @@ dependencies {
     // Awala
     implementation 'tech.relaycorp:awala:1.66.3'
     implementation 'tech.relaycorp:awala-keystore-file:1.6.1'
-    implementation 'tech.relaycorp:cogrpc:1.1.21'
-    implementation 'tech.relaycorp:cogrpc-okhttp:1.1.12'
+    implementation 'tech.relaycorp:cogrpc:1.1.27'
+    implementation 'tech.relaycorp:cogrpc-okhttp:1.1.15'
     testImplementation "tech.relaycorp:awala-testing:$awalaTestingVersion"
     androidTestImplementation "tech.relaycorp:awala-testing:$awalaTestingVersion"
 

--- a/app/src/main/java/tech/relaycorp/gateway/data/preference/InternetGatewayPreferences.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/data/preference/InternetGatewayPreferences.kt
@@ -36,8 +36,6 @@ class InternetGatewayPreferences
     fun observeAddress(): Flow<String> = { address }.toFlow()
     suspend fun setAddress(value: String) = address.setAndCommit(value)
 
-    suspend fun getCogRPCAddress() = "https://${getAddress()}"
-
     @Throws(InternetAddressResolutionException::class)
     suspend fun getPoWebAddress() = resolveServiceAddress.resolvePoWeb(getAddress())
 

--- a/app/src/main/java/tech/relaycorp/gateway/domain/courier/GenerateCCA.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/domain/courier/GenerateCCA.kt
@@ -40,7 +40,7 @@ class GenerateCCA
         val cca = CargoCollectionAuthorization(
             recipient = Recipient(
                 internetGatewayPreferences.getId(),
-                internetGatewayPreferences.getCogRPCAddress()
+                internetGatewayPreferences.getAddress()
             ),
             payload = ccrCiphertext,
             senderCertificate = localConfig.getIdentityCertificate(),

--- a/app/src/main/java/tech/relaycorp/gateway/domain/courier/GenerateCargo.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/domain/courier/GenerateCargo.kt
@@ -92,7 +92,7 @@ class GenerateCargo
         val identityKey = localConfig.getIdentityKey()
         val identityCert = localConfig.getIdentityCertificate()
 
-        val recipientAddress = internetGatewayPreferences.getCogRPCAddress()
+        val recipientAddress = internetGatewayPreferences.getAddress()
         val recipientId = internetGatewayPreferences.getId()
         val creationDate = calculateCreationDate.calculate()
 

--- a/app/src/test/java/tech/relaycorp/gateway/domain/courier/GenerateCCATest.kt
+++ b/app/src/test/java/tech/relaycorp/gateway/domain/courier/GenerateCCATest.kt
@@ -59,7 +59,7 @@ class GenerateCCATest : BaseDataTestCase() {
 
             whenever(internetGatewayPreferences.getId())
                 .thenReturn(PDACertPath.INTERNET_GW.subjectId)
-            whenever(internetGatewayPreferences.getCogRPCAddress()).thenReturn(ADDRESS)
+            whenever(internetGatewayPreferences.getAddress()).thenReturn(ADDRESS)
             whenever(internetGatewayPreferences.getPublicKey())
                 .thenReturn(KeyPairSet.INTERNET_GW.public)
 

--- a/app/src/test/java/tech/relaycorp/gateway/domain/courier/GenerateCargoTest.kt
+++ b/app/src/test/java/tech/relaycorp/gateway/domain/courier/GenerateCargoTest.kt
@@ -49,7 +49,7 @@ class GenerateCargoTest : BaseDataTestCase() {
         registerPrivateGatewayIdentity()
         whenever(internetGatewayPreferences.getId())
             .thenReturn(PDACertPath.INTERNET_GW.subjectId)
-        whenever(internetGatewayPreferences.getCogRPCAddress())
+        whenever(internetGatewayPreferences.getAddress())
             .thenReturn("example.org")
         whenever(internetGatewayPreferences.getPublicKey())
             .thenReturn(KeyPairSet.INTERNET_GW.public)
@@ -88,7 +88,7 @@ class GenerateCargoTest : BaseDataTestCase() {
 
         val cargo = Cargo.deserialize(cargoes.first().readBytes())
         assertEquals(
-            internetGatewayPreferences.getCogRPCAddress(),
+            internetGatewayPreferences.getAddress(),
             cargo.recipient.internetAddress
         )
         assertTrue(Duration.between(parcel.expirationTimeUtc, cargo.expiryDate).abs().seconds <= 2)


### PR DESCRIPTION
We were still using URLs.

Also upgrade gRPC deps to fix other issues that prevented me from testing this fix.
