### PR TITLE
fix(deps): Upgrade PoWeb library to v1.5.54

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -159,7 +159,7 @@ dependencies {
     implementation 'org.conscrypt:conscrypt-android:2.5.2'
 
     // Local and Internet-based Parcel Delivery Connections (PDCs)
-    implementation 'tech.relaycorp:poweb:1.5.53'
+    implementation 'tech.relaycorp:poweb:1.5.54'
     implementation "io.ktor:ktor-server-core:$ktorVersion"
     implementation "io.ktor:ktor-server-netty:$ktorVersion"
     implementation "io.ktor:ktor-utils:$ktorVersion"


### PR DESCRIPTION
So we can get this fix: https://github.com/relaycorp/awala-poweb-jvm/pull/282
