### PR TITLE
fix: Register gateway on sync

### DIFF
--- a/app/src/main/java/tech/relaycorp/gateway/App.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/App.kt
@@ -23,7 +23,6 @@ import tech.relaycorp.gateway.common.di.AppComponent
 import tech.relaycorp.gateway.common.di.DaggerAppComponent
 import tech.relaycorp.gateway.domain.LocalConfig
 import tech.relaycorp.gateway.domain.publicsync.PublicSync
-import tech.relaycorp.gateway.domain.publicsync.RegisterGateway
 import java.security.Security
 import java.time.Duration
 import java.util.logging.Level
@@ -57,9 +56,6 @@ open class App : Application() {
     lateinit var localConfig: LocalConfig
 
     @Inject
-    lateinit var registerGateway: RegisterGateway
-
-    @Inject
     lateinit var publicSync: PublicSync
 
     @Inject
@@ -77,8 +73,8 @@ open class App : Application() {
 
         backgroundScope.launch {
             bootstrapGateway()
-            startPublicSyncWhenPossible()
-            deleteExpiredCertificates()
+            launch { startPublicSyncWhenPossible() }
+            launch { deleteExpiredCertificates() }
         }
 
         registerActivityLifecycleCallbacks(foregroundAppMonitor)
@@ -132,7 +128,6 @@ open class App : Application() {
     private suspend fun bootstrapGateway() {
         if (mode != Mode.Test) {
             localConfig.bootstrap()
-            registerGateway.registerIfNeeded()
         }
     }
 

--- a/app/src/main/java/tech/relaycorp/gateway/domain/publicsync/RegisterGateway.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/domain/publicsync/RegisterGateway.kt
@@ -136,6 +136,6 @@ class RegisterGateway
     }
 
     companion object {
-        private val ABOUT_TO_EXPIRE = Duration.ofDays(25)
+        private val ABOUT_TO_EXPIRE = Duration.ofDays(90)
     }
 }

--- a/app/src/main/java/tech/relaycorp/gateway/domain/publicsync/RegisterGateway.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/domain/publicsync/RegisterGateway.kt
@@ -1,5 +1,7 @@
 package tech.relaycorp.gateway.domain.publicsync
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import tech.relaycorp.gateway.common.Logging.logger
 import tech.relaycorp.gateway.data.doh.InternetAddressResolutionException
 import tech.relaycorp.gateway.data.doh.ResolveServiceAddress
@@ -16,7 +18,9 @@ import java.time.Duration
 import java.time.ZonedDateTime
 import java.util.logging.Level
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 @JvmSuppressWildcards
 class RegisterGateway
 @Inject constructor(
@@ -28,36 +32,42 @@ class RegisterGateway
     private val publicKeyStore: SessionPublicKeyStore
 ) {
 
+    private val mutex = Mutex()
+
     suspend fun registerIfNeeded(): Result {
-        val isFirstRegistration =
-            internetGatewayPreferences.getRegistrationState() == RegistrationState.ToDo
+        mutex.withLock {
+            val isFirstRegistration =
+                internetGatewayPreferences.getRegistrationState() == RegistrationState.ToDo
 
-        if (
-            !isFirstRegistration &&
-            !currentCertificateIsAboutToExpire()
-        ) {
-            return Result.AlreadyRegisteredAndNotExpiring
-        }
-
-        val address = internetGatewayPreferences.getAddress()
-        val result = register(address)
-        if (result is Result.Registered) {
-            saveSuccessfulResult(address, result.pnr)
-
-            if (!isFirstRegistration) {
-                gatewayCertificateChangeNotifier.notifyAll()
+            if (
+                !isFirstRegistration &&
+                !currentCertificateIsAboutToExpire()
+            ) {
+                return Result.AlreadyRegisteredAndNotExpiring
             }
-        }
 
-        return result
+            val address = internetGatewayPreferences.getAddress()
+            val result = register(address)
+            if (result is Result.Registered) {
+                saveSuccessfulResult(address, result.pnr)
+
+                if (!isFirstRegistration) {
+                    gatewayCertificateChangeNotifier.notifyAll()
+                }
+            }
+
+            return result
+        }
     }
 
     suspend fun registerNewAddress(newAddress: String): Result {
-        val result = register(newAddress)
-        if (result is Result.Registered) {
-            saveSuccessfulResult(newAddress, result.pnr)
+        mutex.withLock {
+            val result = register(newAddress)
+            if (result is Result.Registered) {
+                saveSuccessfulResult(newAddress, result.pnr)
+            }
+            return result
         }
-        return result
     }
 
     private suspend fun currentCertificateIsAboutToExpire() =
@@ -65,6 +75,8 @@ class RegisterGateway
 
     private suspend fun register(address: String): Result {
         return try {
+            logger.info("Registering with $address")
+
             val poWebAddress = resolveServiceAddress.resolvePoWeb(address)
             val poWeb = poWebClientBuilder.build(poWebAddress)
             val privateKey = localConfig.getIdentityKey()
@@ -114,13 +126,16 @@ class RegisterGateway
     }
 
     sealed class Result {
-        object FailedToResolve : Result()
-        object FailedToRegister : Result()
+        data object FailedToResolve : Result()
+        data object FailedToRegister : Result()
         data class Registered(val pnr: PrivateNodeRegistration) : Result()
-        object AlreadyRegisteredAndNotExpiring : Result()
+        data object AlreadyRegisteredAndNotExpiring : Result()
+
+        val isSuccessful
+            get() = this is Registered || this is AlreadyRegisteredAndNotExpiring
     }
 
     companion object {
-        private val ABOUT_TO_EXPIRE = Duration.ofDays(90)
+        private val ABOUT_TO_EXPIRE = Duration.ofDays(25)
     }
 }


### PR DESCRIPTION
Closes #714

Also fixes 2 issues I found:
- Certificates weren't deleted if expired, because that method was called after the never-ending public sync method
- The gateway certificate we received expires after 30 days, and we were always renewing them if the expiration date was less than 90 days (changed to 25 days)