### PR TITLE
fix: Introduce allow list in StrictMode

### DIFF
--- a/app/src/main/java/tech/relaycorp/gateway/App.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/App.kt
@@ -1,8 +1,6 @@
 package tech.relaycorp.gateway
 
 import android.app.Application
-import android.os.Build
-import android.os.StrictMode
 import androidx.annotation.VisibleForTesting
 import androidx.work.Configuration
 import androidx.work.Constraints
@@ -73,7 +71,9 @@ open class App : Application() {
 
         enqueuePublicSyncWorker()
 
-        setupStrictMode()
+        if (BuildConfig.DEBUG && mode != Mode.Test) {
+            StrictModeSetup(this)
+        }
 
         backgroundScope.launch {
             bootstrapGateway()
@@ -87,42 +87,6 @@ open class App : Application() {
     private fun setupLogger() {
         LogManager.getLogManager()
         Logging.level = if (BuildConfig.DEBUG) Level.ALL else Level.WARNING
-    }
-
-    private fun setupStrictMode() {
-        if (BuildConfig.DEBUG && mode != Mode.Test) {
-            StrictMode.setThreadPolicy(
-                StrictMode.ThreadPolicy.Builder().detectAll().penaltyLog().penaltyDeath().build()
-            )
-            StrictMode.setVmPolicy(
-                /*
-                  To disable the some of the checks we need to manually set all checks.
-                  This code is based on the `detectAll()` implementation.
-                  Checks disabled:
-                  - UntaggedSockets (we aren't able to tag Netty socket threads)
-                  - CleartextNetwork (it's considering gRPC over TLS communication as cleartext)
-                 */
-                StrictMode.VmPolicy.Builder()
-                    .detectLeakedSqlLiteObjects()
-                    .detectActivityLeaks()
-                    .detectLeakedClosableObjects()
-                    .detectLeakedRegistrationObjects()
-                    .detectFileUriExposure()
-                    .apply {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                            detectContentUriWithoutPermission()
-                        }
-                    }
-                    .apply {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                            detectCredentialProtectedWhileLocked()
-                        }
-                    }
-                    .penaltyLog()
-                    .penaltyDeath()
-                    .build()
-            )
-        }
     }
 
     private fun setupTLSProvider() {

--- a/app/src/main/java/tech/relaycorp/gateway/StrictModeSetup.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/StrictModeSetup.kt
@@ -1,0 +1,95 @@
+package tech.relaycorp.gateway
+
+import android.content.Context
+import android.os.Build
+import android.os.StrictMode
+import android.os.StrictMode.OnThreadViolationListener
+import android.os.StrictMode.OnVmViolationListener
+import android.os.strictmode.Violation
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import tech.relaycorp.gateway.common.Logging.logger
+import java.util.logging.Level
+
+object StrictModeSetup {
+    operator fun invoke(context: Context) {
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy.Builder()
+                .detectAll()
+                .apply {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        penaltyListener(
+                            ContextCompat.getMainExecutor(context),
+                            ThreadPolicyViolationListener()
+                        )
+                    } else {
+                        penaltyLog()
+                    }
+                }
+                .build()
+        )
+        StrictMode.setVmPolicy(
+            StrictMode.VmPolicy.Builder()
+                .detectAll()
+                .apply {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        penaltyListener(
+                            ContextCompat.getMainExecutor(context),
+                            VMViolationListener()
+                        )
+                    } else {
+                        penaltyLog()
+                    }
+                }
+                .build()
+        )
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    private class ThreadPolicyViolationListener : OnThreadViolationListener {
+        override fun onThreadViolation(violation: Violation) {
+            val isAllowed = violation.stackTrace.any { element ->
+                THREAD_POLICY_ALLOWLIST.any {
+                    element.toString().contains(it)
+                }
+            }
+            if (isAllowed) {
+                logger.log(Level.FINE, "StrictMode violation allowed: $violation")
+            } else {
+                throw violation
+            }
+        }
+    }
+
+    private val THREAD_POLICY_ALLOWLIST = listOf(
+        // Huawei startup font loading
+        "Typeface.loadSystemFonts",
+        // Xiaomi startup font loading
+        "TypefaceUtils.loadFontSettings"
+    )
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    private class VMViolationListener : OnVmViolationListener {
+        override fun onVmViolation(violation: Violation) {
+            val isAllowed = violation.stackTrace.any { element ->
+                VM_POLICY_ALLOWLIST.any {
+                    element.toString().contains(it)
+                }
+            }
+            if (isAllowed) {
+                logger.log(Level.FINE, "StrictMode violation allowed: $violation")
+            } else {
+                throw violation
+            }
+        }
+    }
+
+    private val VM_POLICY_ALLOWLIST = listOf(
+        // UntaggedSockets (we aren't able to tag Netty socket threads)
+        "okhttp3.internal.connection.RealConnection.connectSocket",
+        "io.ktor.client.engine",
+        "io.ktor.network.sockets",
+        "io.netty.channel.socket",
+        "io.grpc.okhttp"
+    )
+}


### PR DESCRIPTION
Closes #708

The allow list will need more fine-tuning. @gnarea You will need to get your stacktraces there to get this working for you.

For devices lower than Android P, StrictMode will no longer crash, just log issues.