### PR TITLE
fix: Don't do network calls when apps are in background

### DIFF
--- a/app/src/androidTest/java/tech/relaycorp/gateway/background/endpoint/EndpointPreRegistrationServiceTest.kt
+++ b/app/src/androidTest/java/tech/relaycorp/gateway/background/endpoint/EndpointPreRegistrationServiceTest.kt
@@ -8,7 +8,6 @@ import android.os.Message
 import android.os.Messenger
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.rule.ServiceTestRule
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -45,7 +44,7 @@ class EndpointPreRegistrationServiceTest {
     lateinit var internetGatewayPreferences: InternetGatewayPreferences
 
     private val coroutineContext
-        get() = app.backgroundScope.coroutineContext + UnconfinedTestDispatcher()
+        get() = (getApplicationContext() as App).backgroundContext
 
     @Before
     fun setUp() {
@@ -117,7 +116,7 @@ class EndpointPreRegistrationServiceTest {
         internetGatewayPreferences.setRegistrationState(RegistrationState.ToDo)
 
         val serviceIntent = Intent(
-            getApplicationContext<Context>(),
+            getApplicationContext(),
             EndpointPreRegistrationService::class.java,
         )
         val binder = serviceRule.bindService(serviceIntent)

--- a/app/src/androidTest/java/tech/relaycorp/gateway/background/endpoint/GatewaySyncServiceParcelCollectionTest.kt
+++ b/app/src/androidTest/java/tech/relaycorp/gateway/background/endpoint/GatewaySyncServiceParcelCollectionTest.kt
@@ -6,7 +6,6 @@ import androidx.test.rule.ServiceTestRule
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -14,6 +13,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import tech.relaycorp.gateway.App
 import tech.relaycorp.gateway.data.model.RecipientLocation
 import tech.relaycorp.gateway.domain.StoreParcel
 import tech.relaycorp.gateway.pdc.local.PDCServer
@@ -45,7 +45,7 @@ class GatewaySyncServiceParcelCollectionTest {
     lateinit var storeParcel: StoreParcel
 
     private val coroutineContext
-        get() = UnconfinedTestDispatcher()
+        get() = (getApplicationContext() as App).backgroundContext
 
     @Before
     fun setUp() {
@@ -55,6 +55,7 @@ class GatewaySyncServiceParcelCollectionTest {
 
     @After
     fun tearDown() {
+        serviceRule.unbindService()
         Thread.sleep(3000) // Wait for netty to properly stop, to avoid a RejectedExecutionException
     }
 

--- a/app/src/androidTest/java/tech/relaycorp/gateway/test/TestApp.kt
+++ b/app/src/androidTest/java/tech/relaycorp/gateway/test/TestApp.kt
@@ -1,5 +1,6 @@
 package tech.relaycorp.gateway.test
 
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import tech.relaycorp.gateway.App
 import tech.relaycorp.gateway.TestAppModule
 
@@ -7,6 +8,8 @@ open class TestApp : App() {
     override val component: AppTestComponent = DaggerAppTestComponent.builder()
         .testAppModule(TestAppModule(this))
         .build() as AppTestComponent
+
+    override val backgroundContext = UnconfinedTestDispatcher()
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/tech/relaycorp/gateway/App.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/App.kt
@@ -44,8 +44,10 @@ open class App : Application() {
         }
     }
 
+    open val backgroundContext = Dispatchers.IO
+
     @VisibleForTesting
-    val backgroundScope = CoroutineScope(Dispatchers.IO)
+    val backgroundScope get() = CoroutineScope(backgroundContext)
 
     @Inject
     lateinit var foregroundAppMonitor: ForegroundAppMonitor

--- a/app/src/main/java/tech/relaycorp/gateway/AppModule.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/AppModule.kt
@@ -7,6 +7,7 @@ import android.net.ConnectivityManager
 import android.net.wifi.WifiManager
 import dagger.Module
 import dagger.Provides
+import kotlin.coroutines.CoroutineContext
 
 @Module
 open class AppModule(
@@ -34,4 +35,7 @@ open class AppModule(
 
     @Provides
     fun wifiManager() = app.getSystemService(Context.WIFI_SERVICE) as WifiManager
+
+    @Provides
+    fun backgroundCoroutineContext(): CoroutineContext = app.backgroundContext
 }

--- a/app/src/main/java/tech/relaycorp/gateway/pdc/local/routes/ParcelCollectionRoute.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/pdc/local/routes/ParcelCollectionRoute.kt
@@ -56,6 +56,10 @@ class ParcelCollectionRoute
         }
     }
 
+    fun stop() {
+        asyncJob.cancel()
+    }
+
     private suspend fun DefaultWebSocketServerSession.handle() {
         if (call.request.header(HEADER_ORIGIN) != null) {
             // The client is most likely a (malicious) web page


### PR DESCRIPTION
Addresses https://github.com/relaycorp/relaynet-gateway-android/issues/724

The other task needed to close this ticket is to have endpoint apps bind and unbind from the Gateway when they are in the foreground/background.