### PR TITLE
fix: Endpoint pre-registration should return GATEWAY_NOT_REGISTERED if gateway's certificate is expired

### DIFF
--- a/app/src/main/java/tech/relaycorp/gateway/background/endpoint/EndpointPreRegistrationService.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/background/endpoint/EndpointPreRegistrationService.kt
@@ -16,6 +16,7 @@ import tech.relaycorp.gateway.background.component
 import tech.relaycorp.gateway.common.Logging.logger
 import tech.relaycorp.gateway.data.model.RegistrationState
 import tech.relaycorp.gateway.data.preference.InternetGatewayPreferences
+import tech.relaycorp.gateway.domain.LocalConfig
 import tech.relaycorp.gateway.domain.endpoint.EndpointRegistration
 import java.util.logging.Level
 import javax.inject.Inject
@@ -25,6 +26,9 @@ class EndpointPreRegistrationService : Service() {
 
     @Inject
     lateinit var internetGatewayPreferences: InternetGatewayPreferences
+
+    @Inject
+    lateinit var localConfig: LocalConfig
 
     @Inject
     lateinit var endpointRegistration: EndpointRegistration
@@ -66,6 +70,11 @@ class EndpointPreRegistrationService : Service() {
 
             internetGatewayPreferences.getRegistrationState() != RegistrationState.Done -> {
                 logger.log(Level.WARNING, "Gateway not ready for registration")
+                Message.obtain(null, GATEWAY_NOT_REGISTERED)
+            }
+
+            localConfig.getAllValidIdentityCertificates().isEmpty() -> {
+                logger.log(Level.WARNING, "Gateway's certificate has expired")
                 Message.obtain(null, GATEWAY_NOT_REGISTERED)
             }
 


### PR DESCRIPTION
Related with https://github.com/relaycorp/relaynet-gateway-android/pull/726