### PR TITLE
fix: Cap generated cargo TTL at 180 days

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -150,7 +150,7 @@ dependencies {
     kapt 'com.google.dagger:dagger-compiler:2.48.1'
 
     // Awala
-    implementation 'tech.relaycorp:awala:1.67.10'
+    implementation 'tech.relaycorp:awala:1.69.0'
     implementation 'tech.relaycorp:awala-keystore-file:1.6.31'
     implementation 'tech.relaycorp:cogrpc:1.1.32'
     implementation 'tech.relaycorp:cogrpc-okhttp:1.1.28'

--- a/app/src/main/java/tech/relaycorp/gateway/domain/courier/GenerateCargo.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/domain/courier/GenerateCargo.kt
@@ -22,6 +22,7 @@ import tech.relaycorp.relaynet.messages.payloads.CargoMessageSetWithExpiry
 import tech.relaycorp.relaynet.messages.payloads.CargoMessageWithExpiry
 import tech.relaycorp.relaynet.messages.payloads.batch
 import tech.relaycorp.relaynet.nodes.GatewayManager
+import tech.relaycorp.relaynet.ramf.RAMFMessage
 import java.io.InputStream
 import java.time.Duration
 import java.util.Collections.min
@@ -107,7 +108,7 @@ class GenerateCargo
             payload = cargoMessageSetCiphertext,
             senderCertificate = cda,
             creationDate = creationDate,
-            ttl = min(listOf(ttl, 180.days.inWholeSeconds.toInt())),
+            ttl = min(listOf(ttl, RAMFMessage.MAX_TTL_SECONDS)),
         )
         return cargo.serialize(identityKey)
     }

--- a/app/src/main/java/tech/relaycorp/gateway/domain/courier/GenerateCargo.kt
+++ b/app/src/main/java/tech/relaycorp/gateway/domain/courier/GenerateCargo.kt
@@ -29,7 +29,6 @@ import java.util.Collections.min
 import java.util.logging.Level
 import javax.inject.Inject
 import javax.inject.Provider
-import kotlin.time.Duration.Companion.days
 
 class GenerateCargo
 @Inject constructor(


### PR DESCRIPTION
Which is the limit. When exceeded, an exception is thrown.

TODO:

- [x] Use `RAMFMessage.MAX_TTL_SECONDS`.
